### PR TITLE
call sortChange on th click

### DIFF
--- a/packages/style/ve-table.less
+++ b/packages/style/ve-table.less
@@ -89,7 +89,7 @@
                                 height: 16px;
                                 margin-left: 5px;
                                 color: @ve-table-sort-icon-default-color;
-                                cursor: pointer;
+                                pointer-events: none;
                                 .ve-table-sort-icon {
                                     position: absolute;
                                     display: block;
@@ -106,6 +106,10 @@
                                         color: @ve-table-sort-icon-active-color;
                                     }
                                 }
+                            }
+
+                            &.ve-table-sortable-column {
+                                cursor: pointer;
                             }
 
                             /* filter */

--- a/packages/ve-table/src/header/header-th.jsx
+++ b/packages/ve-table/src/header/header-th.jsx
@@ -167,6 +167,19 @@ export default {
 
             return result;
         },
+        // is sortable column
+        isSortableCloumn() {
+            let result = false;
+
+            const { sortColumns, groupColumnItem } = this;
+            const currentField = groupColumnItem.field;
+
+            if (Object.keys(sortColumns).includes(currentField)) {
+                result = true;
+            }
+
+            return result;
+        },
     },
     methods: {
         /*
@@ -183,6 +196,7 @@ export default {
                 [clsName("first-right-fixed-column")]:
                     this.isfirstRightFixedColumn,
                 [clsName("last-column")]: this.isLastCloumn,
+                [clsName("sortable-column")]: this.isSortableCloumn,
             };
 
             const {
@@ -378,9 +392,6 @@ export default {
 
                 const props = {
                     class: clsName("sort"),
-                    on: {
-                        click: () => this.sortChange(),
-                    },
                 };
 
                 result = (
@@ -592,6 +603,10 @@ export default {
         const events = {
             click: (e) => {
                 this.cellClick(e, click);
+
+                if (this.isSortableCloumn) {
+                    this.sortChange();
+                }
             },
             dblclick: (e) => {
                 this.cellDblclick(e, dblclick);

--- a/packages/ve-table/src/header/header-th.jsx
+++ b/packages/ve-table/src/header/header-th.jsx
@@ -604,7 +604,10 @@ export default {
             click: (e) => {
                 this.cellClick(e, click);
 
-                if (this.isSortableCloumn) {
+                if (
+                    this.isSortableCloumn &&
+                    e.target instanceof HTMLTableCellElement
+                ) {
                     this.sortChange();
                 }
             },

--- a/tests/unit/specs/__snapshots__/ve-table-header-sort.spec.js.snap
+++ b/tests/unit/specs/__snapshots__/ve-table-header-sort.spec.js.snap
@@ -16,8 +16,8 @@ exports[`veTable header sort render multiple field sort 1`] = `
           <thead class="ve-table-fixed-header ve-table-header">
             <tr class="ve-table-header-tr">
               <th rowspan="1" colspan="1" class="ve-table-header-th" style="text-align: left; top: 0px;">Name</th>
-              <th rowspan="1" colspan="1" class="ve-table-header-th" style="text-align: center; top: 0px;">Age<span class="ve-table-sort"><i class="ve-icon iconfont-vet icon-vet-sort-top-arrow ve-table-sort-icon ve-table-sort-icon-top"></i><i class="ve-icon iconfont-vet icon-vet-sort-bottom-arrow ve-table-sort-icon ve-table-sort-icon-bottom"></i></span></th>
-              <th rowspan="1" colspan="1" class="ve-table-header-th" style="text-align: center; top: 0px;">Weight(kg)<span class="ve-table-sort"><i class="ve-icon iconfont-vet icon-vet-sort-top-arrow ve-table-sort-icon ve-table-sort-icon-top active"></i><i class="ve-icon iconfont-vet icon-vet-sort-bottom-arrow ve-table-sort-icon ve-table-sort-icon-bottom"></i></span></th>
+              <th rowspan="1" colspan="1" class="ve-table-header-th ve-table-sortable-column" style="text-align: center; top: 0px;">Age<span class="ve-table-sort"><i class="ve-icon iconfont-vet icon-vet-sort-top-arrow ve-table-sort-icon ve-table-sort-icon-top"></i><i class="ve-icon iconfont-vet icon-vet-sort-bottom-arrow ve-table-sort-icon ve-table-sort-icon-bottom"></i></span></th>
+              <th rowspan="1" colspan="1" class="ve-table-header-th ve-table-sortable-column" style="text-align: center; top: 0px;">Weight(kg)<span class="ve-table-sort"><i class="ve-icon iconfont-vet icon-vet-sort-top-arrow ve-table-sort-icon ve-table-sort-icon-top active"></i><i class="ve-icon iconfont-vet icon-vet-sort-bottom-arrow ve-table-sort-icon ve-table-sort-icon-bottom"></i></span></th>
               <th rowspan="1" colspan="1" class="ve-table-header-th" style="text-align: center; top: 0px;">Hobby</th>
               <th rowspan="1" colspan="1" class="ve-table-header-th ve-table-last-column" style="text-align: left; top: 0px;">Address</th>
             </tr>
@@ -96,8 +96,8 @@ exports[`veTable header sort render single field sort 1`] = `
           <thead class="ve-table-fixed-header ve-table-header">
             <tr class="ve-table-header-tr">
               <th rowspan="1" colspan="1" class="ve-table-header-th" style="text-align: left; top: 0px;">Name</th>
-              <th rowspan="1" colspan="1" class="ve-table-header-th" style="text-align: center; top: 0px;">Age<span class="ve-table-sort"><i class="ve-icon iconfont-vet icon-vet-sort-top-arrow ve-table-sort-icon ve-table-sort-icon-top"></i><i class="ve-icon iconfont-vet icon-vet-sort-bottom-arrow ve-table-sort-icon ve-table-sort-icon-bottom"></i></span></th>
-              <th rowspan="1" colspan="1" class="ve-table-header-th" style="text-align: center; top: 0px;">Weight(kg)<span class="ve-table-sort"><i class="ve-icon iconfont-vet icon-vet-sort-top-arrow ve-table-sort-icon ve-table-sort-icon-top active"></i><i class="ve-icon iconfont-vet icon-vet-sort-bottom-arrow ve-table-sort-icon ve-table-sort-icon-bottom"></i></span></th>
+              <th rowspan="1" colspan="1" class="ve-table-header-th ve-table-sortable-column" style="text-align: center; top: 0px;">Age<span class="ve-table-sort"><i class="ve-icon iconfont-vet icon-vet-sort-top-arrow ve-table-sort-icon ve-table-sort-icon-top"></i><i class="ve-icon iconfont-vet icon-vet-sort-bottom-arrow ve-table-sort-icon ve-table-sort-icon-bottom"></i></span></th>
+              <th rowspan="1" colspan="1" class="ve-table-header-th ve-table-sortable-column" style="text-align: center; top: 0px;">Weight(kg)<span class="ve-table-sort"><i class="ve-icon iconfont-vet icon-vet-sort-top-arrow ve-table-sort-icon ve-table-sort-icon-top active"></i><i class="ve-icon iconfont-vet icon-vet-sort-bottom-arrow ve-table-sort-icon ve-table-sort-icon-bottom"></i></span></th>
               <th rowspan="1" colspan="1" class="ve-table-header-th" style="text-align: center; top: 0px;">Hobby</th>
               <th rowspan="1" colspan="1" class="ve-table-header-th ve-table-last-column" style="text-align: left; top: 0px;">Address</th>
             </tr>

--- a/tests/unit/specs/ve-table-header-sort.spec.js
+++ b/tests/unit/specs/ve-table-header-sort.spec.js
@@ -217,7 +217,7 @@ describe("veTable header sort", () => {
                 .exists(),
         ).toBe(true);
 
-        thEls.at(1).find(".ve-table-sort").trigger("click");
+        thEls.at(1).find(".ve-table-sortable-column").trigger("click");
 
         await later();
 
@@ -361,7 +361,7 @@ describe("veTable header sort", () => {
                 .exists(),
         ).toBe(true);
 
-        thEls.at(1).find(".ve-table-sort").trigger("click");
+        thEls.at(1).find(".ve-table-sortable-column").trigger("click");
 
         await later();
 
@@ -425,7 +425,7 @@ describe("veTable header sort", () => {
 
         const thEls = wrapper.findAll(".ve-table-header-tr th");
 
-        thEls.at(1).find(".ve-table-sort").trigger("click");
+        thEls.at(1).find(".ve-table-sortable-column").trigger("click");
 
         await later();
 
@@ -434,7 +434,7 @@ describe("veTable header sort", () => {
             weight: "",
         });
 
-        thEls.at(1).find(".ve-table-sort").trigger("click");
+        thEls.at(1).find(".ve-table-sortable-column").trigger("click");
 
         await later();
 


### PR DESCRIPTION
Sometimes it's very hard to click on sort icons to sort a table column, especially on small screens. So6 it would be great to make the whole th clickable for sortable columns.

For example: https://element.eleme.io/#/en-US/component/table#sorting