### PR TITLE
feature: fixed header add class on vertical scroll

### DIFF
--- a/packages/ve-table/src/index.jsx
+++ b/packages/ve-table/src/index.jsx
@@ -2055,10 +2055,11 @@ export default {
         // set scrolling
         setScrolling(tableContainerRef) {
             if (this.hasFixedColumn) {
-              const { scrollWidth, clientWidth, scrollLeft } =
-                  tableContainerRef;
-              const { previewTableContainerScrollLeft: previewScrollLeft } =
-                  this;
+                const { scrollWidth, clientWidth, scrollLeft } =
+                    tableContainerRef;
+
+                const { previewTableContainerScrollLeft: previewScrollLeft } =
+                    this;
 
                 // 仅横向滚动需要处理
                 if (
@@ -2076,8 +2077,8 @@ export default {
             }
 
             if (this.fixedHeader) {
-              const { scrollTop } = tableContainerRef;
-              this.isVerticalScrolling = scrollTop > 0;
+                const { scrollTop } = tableContainerRef;
+                this.isVerticalScrolling = scrollTop > 0;
             }
         },
 

--- a/packages/ve-table/src/index.jsx
+++ b/packages/ve-table/src/index.jsx
@@ -2054,12 +2054,11 @@ export default {
 
         // set scrolling
         setScrolling(tableContainerRef) {
-          const { scrollWidth, clientWidth, scrollLeft, scrollTop } =
-          tableContainerRef;
-
             if (this.hasFixedColumn) {
-                const { previewTableContainerScrollLeft: previewScrollLeft } =
-                    this;
+              const { scrollWidth, clientWidth, scrollLeft } =
+                  tableContainerRef;
+              const { previewTableContainerScrollLeft: previewScrollLeft } =
+                  this;
 
                 // 仅横向滚动需要处理
                 if (
@@ -2077,6 +2076,7 @@ export default {
             }
 
             if (this.fixedHeader) {
+              const { scrollTop } = tableContainerRef;
               this.isVerticalScrolling = scrollTop > 0;
             }
         },

--- a/packages/ve-table/src/index.jsx
+++ b/packages/ve-table/src/index.jsx
@@ -360,6 +360,8 @@ export default {
             isLeftScrolling: false,
             // is scrolling right
             isRightScrolling: false,
+            // is scrolling vertically
+            isVerticalScrolling: false,
             // has horizontal scroll bar
             hasXScrollBar: false,
             // has vertical scroll bar
@@ -588,6 +590,7 @@ export default {
                 isVirtualScroll,
                 isLeftScrolling,
                 isRightScrolling,
+                isVerticalScrolling,
                 isCellEditing,
                 isAutofillStarting,
                 enableCellSelection,
@@ -598,6 +601,7 @@ export default {
                 [clsName("virtual-scroll")]: isVirtualScroll,
                 [clsName("container-left-scrolling")]: isLeftScrolling,
                 [clsName("container-right-scrolling")]: isRightScrolling,
+                [clsName("container-vertical-scrolling")]: isVerticalScrolling,
                 [clsName("is-cell-editing")]: isCellEditing,
                 [clsName("autofilling")]: isAutofillStarting,
                 // 如果开启单元格选择，则关闭 user-select
@@ -2050,10 +2054,10 @@ export default {
 
         // set scrolling
         setScrolling(tableContainerRef) {
-            if (this.hasFixedColumn) {
-                const { scrollWidth, clientWidth, scrollLeft } =
-                    tableContainerRef;
+          const { scrollWidth, clientWidth, scrollLeft, scrollTop } =
+          tableContainerRef;
 
+            if (this.hasFixedColumn) {
                 const { previewTableContainerScrollLeft: previewScrollLeft } =
                     this;
 
@@ -2070,6 +2074,10 @@ export default {
                 }
                 this.isLeftScrolling = scrollLeft > 0;
                 this.isRightScrolling = scrollWidth - clientWidth > scrollLeft;
+            }
+
+            if (this.fixedHeader) {
+              this.isVerticalScrolling = scrollTop > 0;
             }
         },
 


### PR DESCRIPTION
## Issue Link
https://github.com/Happy-Coding-Clans/vue-easytable/issues/543

## Description
Adding a vertical scrolling class to table's container element, allowing to use custom classes on vertical scroll event.

Example: At the video below, I'm using the container's vertical class to apply a box-shadow into the table headers.

## Media
https://user-images.githubusercontent.com/22968298/217690113-15f75024-5952-43ec-92a0-ea65de2bd41e.mp4

