### PR TITLE
fix(body): 修复 addEventListener 事件处理函数为空

### DIFF
--- a/packages/ve-table/src/body/index.jsx
+++ b/packages/ve-table/src/body/index.jsx
@@ -169,8 +169,8 @@ export default {
         };
     },
     computed: {
-        /* 
-        column collenction info 
+        /*
+        column collenction info
         1、style of each column
         2、class of each column
         */
@@ -825,13 +825,6 @@ export default {
                 this.sendToCheckboxAll();
             });
         }
-
-        // add key down event listener
-        document.addEventListener("keydown", this.dealKeydownEvent);
-    },
-    destroyed() {
-        // remove key down event listener
-        document.removeEventListener("keydown", this.dealKeydownEvent);
     },
     render() {
         const {


### PR DESCRIPTION
## 描述

我发现在 `body/index.jsx` 中，并没有找到 `this.dealKeydownEvent`，但在挂载时监听了 `keydown` 事件，由于没有找到这个方法，所以传递给 `addEventListener` 的事件处理函数是一个undefined，导致我在一些环境下产生错误